### PR TITLE
workflows size-label

### DIFF
--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,0 +1,13 @@
+name: size-label
+on: pull_request_target
+jobs:
+  size-label:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: size-label
+      uses: "pascalgn/size-label-action@v0.4.3"
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 
코드리뷰의 분량을 쉽게 알 수 있도록
PR의 사이즈에 따라 label을 붙여주는 github actions을 추가하고자 합니다.

별도 repo에서 테스트하여 이상없음을 확인하였습니다.
소스코드: https://github.com/kuoss/goproject1/blob/main/.github/workflows/size-label.yml
테스트결과: https://github.com/kuoss/goproject1/pulls

#### Which issue(s) this PR fixes (관련 이슈):
없음

#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):
리뷰 감사합니다. 파이팅!

#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

공식문서(repo) https://github.com/pascalgn/size-label-action

단, 공식문서의 사용법 내용이, 현재는 제대로 작동하지 않아서 퍼미션을 추가하였고
해당 repo에도 문서를 수정하도록 PR을 등록했습니다.
1월 12일에 PR을 등록했는데, 2월 20일 현재까지 리뷰는 되지 않고 있네요.
https://github.com/pascalgn/size-label-action/pull/34

참고로 사이즈별 레이블명은 다음과 같습니다. ( 00줄 이상인 경우 레이블 xx )
```json
{
  "0": "XS",
  "10": "S",
  "30": "M",
  "100": "L",
  "500": "XL",
  "1000": "XXL"
}
```