### PR TITLE
PR workflow 속도 개선

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -11,18 +11,10 @@ jobs:
     name: go-licenses
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/cache/restore@v3
-      with:
-        path: /
-        key: ${{ runner.os }}-go-licenses@v1.5.0
     - uses: actions/setup-go@v3
       with:
         go-version: 1.18
     - run: go install github.com/google/go-licenses@v1.5.0
-    - uses: actions/cache/save@v3
-      with:
-        path: /
-        key: ${{ runner.os }}-go-licenses@v1.5.0
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

PR workflow가 너무 느려요.

go-licenses의 cache/save 단계에서 1시간 이상 걸려요.

cache/save 단계를 없애고, 그에 따라 restroe 단계도 없앴어요.

#### Which issue(s) this PR fixes (관련 이슈):

fixes: #30 

#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

리뷰 감사합니다.

#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

없음
