### PR TITLE
workflow go-test

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -83,6 +83,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: go test with coverage
+      working-directory: ./app
       run: go test -v -covermode=count -coverprofile=coverage.out
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -83,7 +83,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: go test with coverage
-      working-directory: ./app
       run: go test -v -covermode=count -coverprofile=coverage.out
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/testutil/testenv.go
+++ b/testutil/testenv.go
@@ -42,7 +42,9 @@ func setenvIntialDiskAvailableBytes() {
 	if os.Getenv("TEST_INITIAL_DISK_AVAILABLE_BYTES") != "" {
 		return
 	}
-	avail, err := getDiskAvailableBytes(config.GetLogRoot())
+	logDirectory := config.GetLogRoot()
+	os.MkdirAll(logDirectory, 0755)
+	avail, err := getDiskAvailableBytes(logDirectory)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

로컬 환경에서 테스트할 때는 로그 디렉토리가 프로젝트 내부 상대경로가 되고, 간편하게 임시로 로그파일을 구성할 수 있습니다. 이렇게 하면 IDE에서 로그파일을 확인하기 편리하다는 장점이 있습니다.
https://github.com/kuoss/lethe/blob/main/testutil/testenv.go#L26

하지만 Actions 환경에서는 작업 디렉토리가 맞지 않아서 그게 안되는 것으로 보입니다.
https://github.com/kuoss/lethe/actions/runs/4321230344/jobs/7542242267#step:4:43

1안) 절대경로로 바꾸거나, 2안) Actions 환경에서도 상대경로가 작동하게 하는 방안이 있을 것 같습니다.

#### Which issue(s) this PR fixes (관련 이슈):

fixes: https://github.com/kuoss/lethe/issues/33

#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

리뷰 감사합니다

#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

https://stackoverflow.com/questions/58139175/running-actions-in-another-directory
