### PR TITLE
mock lethe-writer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,16 @@ go-licenses-report:
 
 go-licenses-check:
 	go-licenses check github.com/kuoss/lethe && echo OK
+
+mock:
+	./scripts/mock/restart.sh
+
+mock-status:
+	./scripts/mock/status.sh
+
+mock-logs:
+	./scripts/mock/logs.sh
+
+mock-delete:
+	./scripts/mock/delete.sh
+

--- a/scripts/mock/delete.sh
+++ b/scripts/mock/delete.sh
@@ -1,0 +1,3 @@
+set -x
+docker rm -f flb
+sudo rm -rf /workspaces/data

--- a/scripts/mock/fluent-bit.conf
+++ b/scripts/mock/fluent-bit.conf
@@ -1,0 +1,54 @@
+[SERVICE]
+    daemon        off
+    log_level     info
+
+[INPUT]
+    name          random
+    tag           node
+    interval_sec  4
+
+[INPU]
+    name          random
+    tag           pod
+    interval_sec  3
+
+[FILTER]
+    name          lua
+    script        mock.lua
+    match         node
+    call          node
+
+[FILTER]
+    name          lua
+    script        mock.lua
+    match         pod
+    call          pod
+
+[FILTER]
+    Name          rewrite_tag
+    Match         node
+    Rule          $tag .* $tag false
+    Emitter_Name  emitter1
+[FILTER]
+    Name          rewrite_tag
+    Match         pod
+    Rule          $tag .* $tag false
+    Emitter_Name  emitter2
+
+[FILTER]
+    Name          modify
+    Match_Regex   ^/(node|pod)
+    Remove        tag
+
+[OUTPUT]
+    Name     file
+    Match    *
+    Path     /workspaces/data/log
+    Mkdir    true
+    Format   template
+    Template {row}
+
+[OUTPUT]
+    Name     stdout
+    Match    *
+

--- a/scripts/mock/logs.sh
+++ b/scripts/mock/logs.sh
@@ -1,0 +1,2 @@
+set -x
+find /workspaces/data/log -type f -exec tail {} +

--- a/scripts/mock/mock.lua
+++ b/scripts/mock/mock.lua
@@ -1,0 +1,37 @@
+function node(tag, timestamp, r)
+    local hostnames = {'node01', 'node02'}
+    local syslog_identifiers = {'kubelet', 'containerd'}
+    local messages = {'hello', 'world'}
+
+    local u = os.date("%Y-%m-%dT%H:%M:%SZ")
+    local hostname = hostnames[math.random(#hostnames)]
+    local syslog_identifier = syslog_identifiers[math.random(#syslog_identifiers)]
+    local message = messages[math.random(#messages)] .. " rand_value=" .. r.rand_value
+
+    return 1, timestamp, {
+        tag = string.format("/node/%s/%s_%s.log", hostname, string.sub(u, 1, 10), string.sub(u, 12, 13)),
+        row = string.format("%s[%s|%s] %s", u, hostname, syslog_identifier, message)
+    }
+end
+
+function pod(tag, timestamp, r)
+    local namespaces = {'default', 'kube-system'}
+    local pods = {'pod1', 'pod2'}
+    local containers = {'main', 'sidecar'}
+    local files = {'hello.go', 'world.go'}
+    local keys = {'foo', 'bar'}
+
+    local u = os.date("%Y-%m-%dT%H:%M:%SZ")
+    local namespace = namespaces[math.random(#namespaces)]
+    local pod = pods[math.random(#pods)]
+    local container = containers[math.random(#containers)]
+
+    local file = files[math.random(#files)]
+    local key = keys[math.random(#keys)]
+    local log = file .. ' ' .. key .. '=' .. r.rand_value
+
+    return 1, timestamp, {
+        tag = string.format("/pod/%s/%s_%s.log", namespace, string.sub(u, 1, 10), string.sub(u, 12, 13)),
+        row = string.format("%s[%s|%s|%s] %s", u, namespace, pod, container, log)
+    }
+end

--- a/scripts/mock/restart.sh
+++ b/scripts/mock/restart.sh
@@ -1,0 +1,11 @@
+cd $(dirname $0)
+IMAGE=fluent/fluent-bit:2.0.9
+
+set -x
+docker rm -f flb
+mkdir -p /workspaces/data/log
+docker run -d --name flb \
+-v $PWD/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf \
+-v $PWD/mock.lua:/fluent-bit/etc/mock.lua \
+-v /workspaces:/workspaces \
+$IMAGE

--- a/scripts/mock/status.sh
+++ b/scripts/mock/status.sh
@@ -1,0 +1,6 @@
+set -x
+docker ps -a | grep flb$
+
+docker logs flb
+
+find /workspaces/data/log -type f


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

개발환경에서 단위 테스트 외에, 보다 실제 환경에 가까운 테스트가 필요하여
lethe-writer mock을 추가합니다.

#### Which issue(s) this PR fixes (관련 이슈):

#38 

#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

mock 내용만 추가되었고 본래의 go 코드에는 영향이 없으므로

특별히 검토할 것이 없고 대략적인 내용만 보시면 됩니다.

codespace 환경에서 테스트하였고, 사용방법은 아래에 적었습니다.


#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

시작(생성)
```
@jmnote ➜ /workspaces/lethe (38-lethe-writer-mock) $ make mock
./scripts/mock/restart.sh
+ docker rm -f flb
flb
+ mkdir -p /workspaces/data/log
+ docker run -d --name flb -v /workspaces/lethe/scripts/mock/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf -v /workspaces/lethe/scripts/mock/mock.lua:/fluent-bit/etc/mock.lua -v /workspaces:/workspaces fluent/fluent-bit:2.0.9
bf9af490588210325ae0421d14d20bd020fb8e73e11731a2ed475844feacba3b
```

상태보기
```
@jmnote ➜ /workspaces/lethe (38-lethe-writer-mock) $ make mock-status
...
+ find /workspaces/data/log -type f
/workspaces/data/log/node/node02/2023-03-09_05.log
/workspaces/data/log/node/node02/2023-03-09_06.log
/workspaces/data/log/node/node01/2023-03-09_05.log
/workspaces/data/log/node/node01/2023-03-09_06.log
/workspaces/data/log/pod/default/2023-03-09_05.log
/workspaces/data/log/pod/default/2023-03-09_06.log
/workspaces/data/log/pod/kube-system/2023-03-09_05.log
```

로그보기
```
@jmnote ➜ /workspaces/lethe (38-lethe-writer-mock) $ make mock-logs
...
==> /workspaces/data/log/pod/kube-system/2023-03-09_06.log <==
2023-03-09T06:38:50Z[kube-system|pod1|main] world.go foo=-1.4417214273662e+17
2023-03-09T06:38:56Z[kube-system|pod2|main] hello.go foo=-5.7478605173591e+18
2023-03-09T06:39:05Z[kube-system|pod1|main] world.go foo=8.8407601554513e+18
2023-03-09T06:39:08Z[kube-system|pod2|main] hello.go foo=-4.3116132209056e+18
2023-03-09T06:39:11Z[kube-system|pod2|sidecar] world.go foo=2.7335337012828e+18
2023-03-09T06:39:20Z[kube-system|pod1|sidecar] hello.go foo=-5.626620372193e+18
2023-03-09T06:39:32Z[kube-system|pod2|sidecar] hello.go bar=6.5818417401541e+18
2023-03-09T06:39:38Z[kube-system|pod2|sidecar] hello.go foo=-3.7263614614599e+18
2023-03-09T06:39:41Z[kube-system|pod2|sidecar] world.go bar=-2.1874799044868e+18
2023-03-09T06:39:44Z[kube-system|pod2|sidecar] hello.go foo=8.7029884008346e+18
```

삭제
```
@jmnote ➜ /workspaces/lethe (38-lethe-writer-mock) $ make mock-delete
./scripts/mock/delete.sh
+ docker rm -f flb
flb
+ sudo rm -rf /workspaces/data
```