### PR TITLE
misspell & gocyclo

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-go@v4
     - run: make gocyclo
 
   goimports:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,8 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: curl -L https://git.io/misspell | bash
-    - run: find . -type f -name '*.*' | xargs ./bin/misspell -error
+    - run: make misspell
+
+  gocyclo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: make gocyclo
 
   goimports:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,6 +17,12 @@ jobs:
         gofmt-path: '.'
         gofmt-flags: '-l -d'
 
+  misspell:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: curl -L https://git.io/misspell | bash
+    - run: find . -type f -name '*.*' | xargs ./bin/misspell -error
 
   goimports:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ cover:
 misspell:
 	hack/misspell.sh
 
+gocyclo:
+	hack/gocyclo.sh
+
 checks:
 	hack/checks.sh
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ test-win:
 cover:
 	hack/test-cover.sh
 
+misspell:
+	hack/misspell.sh
+
 checks:
 	hack/checks.sh
 

--- a/hack/checks.sh
+++ b/hack/checks.sh
@@ -4,6 +4,7 @@ cd $(dirname $0)/..
 set -xeuo pipefail
 go mod tidy
 go fmt ./...
+./hack/misspell.sh
 go vet ./...
 which goimports || go install golang.org/x/tools/cmd/goimports@latest
 goimports -local -v -w .

--- a/hack/gocyclo.sh
+++ b/hack/gocyclo.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -euo pipefail
 cd $(dirname $0)/../
 
 which gocyclo || go install github.com/fzipp/gocyclo/cmd/gocyclo@latest

--- a/hack/gocyclo.sh
+++ b/hack/gocyclo.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+cd $(dirname $0)/../
+
+which gocyclo || go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+
+gocyclo -over 15 -ignore letheql/parser .
+if [[ $? != 0 ]]; then
+    echo "❌ FAIL"
+    exit 1
+fi
+echo "✔️ OK"

--- a/hack/misspell.sh
+++ b/hack/misspell.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+cd $(dirname $0)/..
+
+[ -f ./bin/misspell ] || curl -L https://git.io/misspell | bash
+
+find . -type f -name '*.*' | xargs ./bin/misspell -error
+if [[ $? != 0 ]]; then
+    echo "❌ FAIL - misspell found"
+    exit 1
+fi
+echo "✔️ OK - misspell not found"

--- a/letheql/parser/generated_parser.y.go
+++ b/letheql/parser/generated_parser.y.go
@@ -3,18 +3,15 @@
 //line generated_parser.y:15
 package parser
 
-import __yyfmt__ "fmt"
-
-//line generated_parser.y:15
-
 import (
+	__yyfmt__ "fmt"
 	"math"
 	"strconv"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
-)
+) //line generated_parser.y:15
 
 //line generated_parser.y:28
 type yySymType struct {

--- a/letheql/parser/generated_parser.y.go
+++ b/letheql/parser/generated_parser.y.go
@@ -3,15 +3,18 @@
 //line generated_parser.y:15
 package parser
 
+import __yyfmt__ "fmt"
+
+//line generated_parser.y:15
+
 import (
-	__yyfmt__ "fmt"
 	"math"
 	"strconv"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
-) //line generated_parser.y:15
+)
 
 //line generated_parser.y:28
 type yySymType struct {

--- a/storage/logservice/match/label.go
+++ b/storage/logservice/match/label.go
@@ -15,7 +15,7 @@ func getLabelMatchFuncs(sel *model.LogSelector) ([]MatchFunc, error) {
 	case "pod":
 		return getLabelMatchFuncsDetail(sel, "pod", "container")
 	}
-	return nil, fmt.Errorf("unknwon logType: %s", sel.Name)
+	return nil, fmt.Errorf("unknown logType: %s", sel.Name)
 }
 
 func getLabelMatchFuncsDetail(sel *model.LogSelector, names ...string) ([]MatchFunc, error) {


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

https://goreportcard.com/report/github.com/kuoss/lethe

go report card에서 발견된 이슈( misspell 1건, gocyclo 4건 )에 대한 조치입니다. 각 이슈에 대해 코드 수정 + 재발 방지를 위해 make checks와 github actions를 추가하였습니다. ㅎㅎ


[misspell 1건]

- storage/logservice/match/label.go

에러 메시지에 unknown을 unknwon으로 잘못 써놨었네요. 바로 잡았습니다.


[gocyclo 4건]

- letheql/parser/parser.go
- letheql/parser/lex.go
- letheql/parser/ast.go
- letheql/engine.go

go report에 포함된 gocyclo 이슈 기준은 순환 복잡도 15 초과입니다.
parser는 건드리지 않는 것이 좋으니까 마지막 letheql/engine.go만 조치했습니다.
문제가 되는 부분이 현재는 불필요한 코드여서 삭제했습니다. 참고로 전체 커버리지는 71.11% 입니다.

PS> prometheus repo는 go report에 gocyclo 100%로 되어 있던데, 실제로 점검해보면 15 초과하는 게 많은데 어떻게 100%가 나왔는지는 모르겠네요. 이 부분은 나중에 풀 숙제로 남겨두겠습니다...


#### Which issue(s) this PR fixes (관련 이슈):

- #81 


#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

리뷰 감사합니다.


#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

- https://github.com/fzipp/gocyclo
- https://github.com/client9/misspell
- 