### PR TITLE
init log_data_path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := v0.2.0
+VERSION := v0.2.1
 IMAGE := ghcr.io/kuoss/lethe:$(VERSION)
 
 install-dev:

--- a/storage/fileservice/fileservice.go
+++ b/storage/fileservice/fileservice.go
@@ -2,6 +2,7 @@ package fileservice
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/kuoss/lethe/config"
 	storagedriver "github.com/kuoss/lethe/storage/driver"
@@ -17,6 +18,11 @@ func New(cfg *config.Config) (*FileService, error) {
 	driver, err := factory.Get("filesystem", map[string]interface{}{"RootDirectory": cfg.LogDataPath()})
 	if err != nil {
 		return nil, fmt.Errorf("factory.Get err: %w", err)
+	}
+	// TODO: use driver
+	err = os.MkdirAll(cfg.LogDataPath(), 0755)
+	if err != nil {
+		return nil, fmt.Errorf("mkdirAll err: %w", err)
 	}
 	return &FileService{cfg, driver}, nil
 }

--- a/storage/fileservice/fileservice_test.go
+++ b/storage/fileservice/fileservice_test.go
@@ -1,8 +1,10 @@
 package fileservice
 
 import (
+	"os"
 	"testing"
 
+	"github.com/kuoss/lethe/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -10,4 +12,29 @@ func TestNew(t *testing.T) {
 	assert.NotEmpty(t, fileService)
 	assert.Equal(t, "filesystem", fileService.driver.Name())
 	assert.Equal(t, "tmp/init", fileService.driver.RootDirectory())
+}
+
+func TestNewTemp(t *testing.T) {
+	cfg, err := config.New("test")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, cfg)
+
+	dataPath := "tmp/temp" // caution: RemoveAll()
+
+	cfg.SetLogDataPath(dataPath)
+	tempFileService, err := New(cfg)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, tempFileService)
+	assert.DirExists(t, dataPath) // exists
+
+	// duplicate ok
+	cfg.SetLogDataPath(dataPath)
+	tempFileService2, err := New(cfg)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, tempFileService2)
+	assert.DirExists(t, dataPath) // exists
+
+	// clean up
+	err = os.RemoveAll(dataPath)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

새 PVC를 /data에 마운트하고 log_data_path를 /data/log로 하면 최초에 디렉토리를 만들어주지 않아서 문제가 됩니다. ㅠㅠ

```
time="2023-05-31T05:36:31Z" level=error msg="deleteByAge err: listFiles err: walk err: &{%!e(string=walk err: walkFunc err: lstat /data/log: no such file or directory) %!e(*fmt.wrapError=&{walkFunc err: lstat /data/log: no such file or directory 0xc000466030})}" file="rotator.go:35"
time="2023-05-31T05:36:31Z" level=error msg="deleteBySize err: listFiles err: walk err: &{%!e(string=walk err: walkFunc err: lstat /data/log: no such file or directory) %!e(*fmt.wrapError=&{walkFunc err: lstat /data/log: no such file or directory 0xc000466240})}" file="rotator.go:39"
```

fileService에서 초기화(디렉토리 생성)해주도록 수정했고, 테스트 코드도 추가했습니다.


#### Which issue(s) this PR fixes (관련 이슈):

- #84 


#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

리뷰 감사합니다.


#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

.
