### PR TITLE
88 remove storage driver interface break point

### DIFF
--- a/storage/driver/driver.go
+++ b/storage/driver/driver.go
@@ -16,5 +16,6 @@ type Driver interface {
 	Delete(string) error
 	Walk(string) ([]FileInfo, error)
 	WalkDir(string) ([]string, error)
+	Mkdir(string) error
 	RootDirectory() string
 }

--- a/storage/driver/factory/fake/driver.go
+++ b/storage/driver/factory/fake/driver.go
@@ -51,3 +51,6 @@ func (*driver) Writer(string) (storagedriver.FileWriter, error) {
 func (*driver) RootDirectory() string {
 	return ""
 }
+func (d *driver) Mkdir(string) error {
+	return nil
+}

--- a/storage/driver/filesystem/driver.go
+++ b/storage/driver/filesystem/driver.go
@@ -218,9 +218,8 @@ func (d *driver) WalkDir(subpath string) ([]string, error) {
 }
 
 func (d *driver) Mkdir(subpath string) error {
-	fullpath := d.fullPath(subpath)
-	dir := path.Dir(fullpath)
-	if err := os.MkdirAll(dir, 0777); err != nil {
+
+	if err := os.MkdirAll(subpath, 0777); err != nil {
 		return err
 	}
 	return nil

--- a/storage/driver/filesystem/driver.go
+++ b/storage/driver/filesystem/driver.go
@@ -219,7 +219,7 @@ func (d *driver) WalkDir(subpath string) ([]string, error) {
 
 func (d *driver) Mkdir(subpath string) error {
 
-	if err := os.MkdirAll(subpath, 0777); err != nil {
+	if err := os.MkdirAll(subpath, 0755); err != nil {
 		return err
 	}
 	return nil

--- a/storage/driver/filesystem/driver.go
+++ b/storage/driver/filesystem/driver.go
@@ -216,3 +216,12 @@ func (d *driver) WalkDir(subpath string) ([]string, error) {
 	}
 	return dirs, nil
 }
+
+func (d *driver) Mkdir(subpath string) error {
+	fullpath := d.fullPath(subpath)
+	dir := path.Dir(fullpath)
+	if err := os.MkdirAll(dir, 0777); err != nil {
+		return err
+	}
+	return nil
+}

--- a/storage/fileservice/clean.go
+++ b/storage/fileservice/clean.go
@@ -2,6 +2,7 @@ package fileservice
 
 import (
 	"fmt"
+
 	"github.com/kuoss/common/logger"
 )
 

--- a/storage/fileservice/clean.go
+++ b/storage/fileservice/clean.go
@@ -2,9 +2,6 @@ package fileservice
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/kuoss/common/logger"
 )
 
@@ -14,7 +11,7 @@ func (s *FileService) Clean() {
 }
 
 func (s *FileService) removeFilesWithPrefix(prefix string) {
-	files, err := filepath.Glob(fmt.Sprintf("%s/%s.*", s.config.LogDataPath(), prefix))
+	files, err := s.driver.Walk(fmt.Sprintf("%s/%s.*", s.config.LogDataPath(), prefix))
 	if err != nil {
 		logger.Warnf("glob err: %s, prefix: %s", err.Error(), prefix)
 		return
@@ -25,7 +22,7 @@ func (s *FileService) removeFilesWithPrefix(prefix string) {
 	logger.Warnf("cleansing files prefix: %s", prefix)
 	for _, file := range files {
 		logger.Infof("remove file: %s", file)
-		err := os.Remove(file)
+		err := s.driver.Delete(file.Fullpath())
 		if err != nil {
 			logger.Warnf("remove err: %s, file: %s", err.Error(), file)
 		}

--- a/storage/fileservice/fileservice.go
+++ b/storage/fileservice/fileservice.go
@@ -2,6 +2,7 @@ package fileservice
 
 import (
 	"fmt"
+
 	"github.com/kuoss/lethe/config"
 	storagedriver "github.com/kuoss/lethe/storage/driver"
 	"github.com/kuoss/lethe/storage/driver/factory"

--- a/storage/fileservice/fileservice.go
+++ b/storage/fileservice/fileservice.go
@@ -2,8 +2,6 @@ package fileservice
 
 import (
 	"fmt"
-	"os"
-
 	"github.com/kuoss/lethe/config"
 	storagedriver "github.com/kuoss/lethe/storage/driver"
 	"github.com/kuoss/lethe/storage/driver/factory"
@@ -19,11 +17,12 @@ func New(cfg *config.Config) (*FileService, error) {
 	if err != nil {
 		return nil, fmt.Errorf("factory.Get err: %w", err)
 	}
-	// TODO: use driver
-	err = os.MkdirAll(cfg.LogDataPath(), 0755)
+
+	err = driver.Mkdir(cfg.LogDataPath())
 	if err != nil {
 		return nil, fmt.Errorf("mkdirAll err: %w", err)
 	}
+
 	return &FileService{cfg, driver}, nil
 }
 

--- a/storage/fileservice/fileservice_test.go
+++ b/storage/fileservice/fileservice_test.go
@@ -40,7 +40,7 @@ func TestNewTemp(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestNewFile(t *testing.T) {
+func TestNewLogDataPath(t *testing.T) {
 	cfg, err := config.New("test")
 	assert.NoError(t, err)
 

--- a/storage/fileservice/fileservice_test.go
+++ b/storage/fileservice/fileservice_test.go
@@ -2,6 +2,7 @@ package fileservice
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kuoss/lethe/config"
@@ -37,4 +38,16 @@ func TestNewTemp(t *testing.T) {
 	// clean up
 	err = os.RemoveAll(dataPath)
 	assert.NoError(t, err)
+}
+
+func TestNewFile(t *testing.T) {
+	cfg, err := config.New("test")
+	assert.NoError(t, err)
+
+	cfg.SetLogDataPath(filepath.Join(".", "tmp", "writer"))
+
+	_, err = New(cfg)
+
+	assert.NoError(t, err)
+	assert.DirExists(t, filepath.Join(".", "tmp", "writer"))
 }

--- a/storage/fileservice/fileservice_test.go
+++ b/storage/fileservice/fileservice_test.go
@@ -50,4 +50,6 @@ func TestNewFile(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.DirExists(t, filepath.Join(".", "tmp", "writer"))
+
+	err = os.RemoveAll(filepath.Join(".", "tmp", "writer"))
 }

--- a/storage/fileservice/fileservice_test.go
+++ b/storage/fileservice/fileservice_test.go
@@ -52,4 +52,5 @@ func TestNewFile(t *testing.T) {
 	assert.DirExists(t, filepath.Join(".", "tmp", "writer"))
 
 	err = os.RemoveAll(filepath.Join(".", "tmp", "writer"))
+	assert.NoError(t, err)
 }

--- a/storage/fileservice/list.go
+++ b/storage/fileservice/list.go
@@ -2,7 +2,6 @@ package fileservice
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/kuoss/common/logger"
@@ -77,16 +76,17 @@ func (s *FileService) ListLogDirsWithSize() []LogDir {
 		}
 		logDirs[i].Size = size
 
-		files, err := os.ReadDir(logDir.Fullpath)
+		files, err := s.driver.Walk(logDir.Fullpath)
 		if err != nil {
 			logger.Warnf("readDir err: %s, path:%s", err.Error(), logDir.Fullpath)
 			continue
 		}
+
 		fileCount := len(files)
 		logDirs[i].FileCount = fileCount
 		if fileCount > 0 {
-			logDirs[i].FirstFile = files[0].Name()
-			logDirs[i].LastFile = files[fileCount-1].Name()
+			logDirs[i].FirstFile = filepath.Base(files[0].Fullpath())
+			logDirs[i].LastFile = filepath.Base(files[fileCount-1].Fullpath())
 		}
 	}
 	return logDirs

--- a/storage/fileservice/list.go
+++ b/storage/fileservice/list.go
@@ -75,10 +75,9 @@ func (s *FileService) ListLogDirsWithSize() []LogDir {
 			continue
 		}
 		logDirs[i].Size = size
-
-		files, err := s.driver.Walk(logDir.Fullpath)
+		files, err := s.driver.Walk(logDir.Subpath)
 		if err != nil {
-			logger.Warnf("readDir err: %s, path:%s", err.Error(), logDir.Fullpath)
+			logger.Warnf("walk err: %s, path: %s", err.Error(), logDir.Fullpath)
 			continue
 		}
 


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

`fileservice` 패키지에서 로그파일을 핸들링할 때 `os`,`filepath`패키지를 이용해서 파일시스템에 직접 접근하는 경우가 존재합니다.

로그 저장소가 오브젝트 스토리지로 변경되는 경우를 대비해서 `driver` 인터페이스를 정의했고 해당 인터페이스를 통해서 로그파일을 핸들링해야 합니다. 

이미 인터페이스에 정의되어있는 메서드를 활용하지 않은 경우, 메서드 사용으로 변경만했습니다(`clean.go`,`list.go`). 그러나 `fileservice.New`는 로그 디렉토리가 존재하지 않는 경우 `os.MkdirAll` 을 이용해서 루트 디렉토리를 생성합니다.  이런 '디렉토리 생성'에 해당하는 인터페이스 메서드가 존재하지 않습니다. 

그래서 `driver`의 인터페이스에 `Mkdir` 메서드를 추가했고, `filesystem` driver는 디렉토리만 생성하는 구현을 추가했습니다. 


#### Which issue(s) this PR fixes (관련 이슈):

- #88 


#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

리뷰 감사합니다!


#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):


