### PR TITLE
add fuzz test case within MatchFunc on Label.

### DIFF
--- a/storage/logservice/match/label_test.go
+++ b/storage/logservice/match/label_test.go
@@ -1,11 +1,12 @@
 package match
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/kuoss/lethe/letheql/model"
 	"github.com/kuoss/lethe/letheql/parser"
 	"github.com/prometheus/prometheus/model/labels"
-	"strings"
-	"testing"
 )
 
 func FuzzNodeLabelMatchEqual(f *testing.F) {

--- a/storage/logservice/match/label_test.go
+++ b/storage/logservice/match/label_test.go
@@ -1,9 +1,10 @@
 package match
 
 import (
-	"github.com/stretchr/testify/assert"
 	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/kuoss/lethe/letheql/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -27,7 +28,7 @@ func FuzzNodeLabelMatchEqual(f *testing.F) {
 
 		funcs, err := getLabelMatchFuncs(nodeSel)
 		if err != nil {
-			f.Fail()
+			t.Fail()
 		}
 
 		verfityFunc := funcs[0]
@@ -59,7 +60,7 @@ func FuzzNodeLabelMatchNotEqual(f *testing.F) {
 
 		funcs, err := getLabelMatchFuncs(nodeSel)
 		if err != nil {
-			f.Fail()
+			t.Fail()
 		}
 
 		verfityFunc := funcs[0]

--- a/storage/logservice/match/label_test.go
+++ b/storage/logservice/match/label_test.go
@@ -3,7 +3,6 @@ package match
 import (
 	"github.com/stretchr/testify/assert"
 	"regexp"
-
 	"testing"
 
 	"github.com/kuoss/lethe/letheql/model"
@@ -11,31 +10,31 @@ import (
 )
 
 func FuzzNodeLabelMatchEqual(f *testing.F) {
-	nodeSel := &model.LogSelector{
-		Name: "node",
-		LabelMatchers: []*labels.Matcher{
-			&labels.Matcher{
-				Type:  labels.MatchEqual,
-				Name:  "process",
-				Value: "label_value",
+
+	f.Add("needle", "haystack")
+
+	f.Fuzz(func(t *testing.T, needle, haystack string) {
+		nodeSel := &model.LogSelector{
+			Name: "node",
+			LabelMatchers: []*labels.Matcher{
+				&labels.Matcher{
+					Type:  labels.MatchEqual,
+					Name:  "process",
+					Value: needle,
+				},
 			},
-		},
-	}
+		}
 
-	funcs, err := getLabelMatchFuncs(nodeSel)
-	if err != nil {
-		f.Fail()
-	}
+		funcs, err := getLabelMatchFuncs(nodeSel)
+		if err != nil {
+			f.Fail()
+		}
 
-	verfityFunc := funcs[0]
+		verfityFunc := funcs[0]
 
-	testcases := []string{"label_value", "non_label_value"}
-	for _, tc := range testcases {
-		f.Add(tc)
-	}
-	f.Fuzz(func(t *testing.T, label string) {
-		isMatch := verfityFunc(label)
-		if label == "lable_value" {
+		isMatch := verfityFunc(haystack)
+
+		if needle == haystack {
 			assert.True(t, isMatch)
 		} else {
 			assert.False(t, isMatch)
@@ -44,34 +43,33 @@ func FuzzNodeLabelMatchEqual(f *testing.F) {
 }
 
 func FuzzNodeLabelMatchNotEqual(f *testing.F) {
-	nodeSel := &model.LogSelector{
-		Name: "node",
-		LabelMatchers: []*labels.Matcher{
-			&labels.Matcher{
-				Type:  labels.MatchNotEqual,
-				Name:  "process",
-				Value: "label_value",
+	f.Add("needle", "haystack")
+
+	f.Fuzz(func(t *testing.T, needle, haystack string) {
+		nodeSel := &model.LogSelector{
+			Name: "node",
+			LabelMatchers: []*labels.Matcher{
+				&labels.Matcher{
+					Type:  labels.MatchNotEqual,
+					Name:  "process",
+					Value: needle,
+				},
 			},
-		},
-	}
+		}
 
-	funcs, err := getLabelMatchFuncs(nodeSel)
-	if err != nil {
-		f.Fail()
-	}
+		funcs, err := getLabelMatchFuncs(nodeSel)
+		if err != nil {
+			f.Fail()
+		}
 
-	verfityFunc := funcs[0]
+		verfityFunc := funcs[0]
 
-	testcases := []string{"label_value", "non_label_value"}
-	for _, tc := range testcases {
-		f.Add(tc)
-	}
-	f.Fuzz(func(t *testing.T, label string) {
-		isMatch := verfityFunc(label)
-		if label == "lable_value" {
-			assert.False(t, isMatch)
-		} else {
+		isMatch := verfityFunc(haystack)
+
+		if needle != haystack {
 			assert.True(t, isMatch)
+		} else {
+			assert.False(t, isMatch)
 		}
 	})
 }

--- a/storage/logservice/match/label_test.go
+++ b/storage/logservice/match/label_test.go
@@ -33,8 +33,7 @@ func FuzzNodeLabelMatchEqual(f *testing.F) {
 		f.Fail()
 	}
 
-	var verfityFunc MatchFunc
-	verfityFunc = funcs[0]
+	verfityFunc := funcs[0]
 
 	testcases := []string{"label_value", "non_label_value"}
 	for _, tc := range testcases {
@@ -75,8 +74,7 @@ func FuzzNodeLabelMatchNotEqual(f *testing.F) {
 		f.Fail()
 	}
 
-	var verfityFunc MatchFunc
-	verfityFunc = funcs[0]
+	verfityFunc := funcs[0]
 
 	testcases := []string{"label_value", "non_label_value"}
 	for _, tc := range testcases {
@@ -117,8 +115,7 @@ func FuzzNodeLabelMatchRegexOnlyContains(f *testing.F) {
 		f.Fail()
 	}
 
-	var verfityFunc MatchFunc
-	verfityFunc = funcs[0]
+	verfityFunc := funcs[0]
 
 	testcases := []string{"foobar", "foobaar", "regardless"}
 	for _, tc := range testcases {
@@ -156,8 +153,7 @@ func FuzzNodeLabelMatchRegexNotEqualOnlyContains(f *testing.F) {
 		f.Fail()
 	}
 
-	var verfityFunc MatchFunc
-	verfityFunc = funcs[0]
+	verfityFunc := funcs[0]
 
 	testcases := []string{"foobar", "foobaar", "regardless"}
 	for _, tc := range testcases {

--- a/storage/logservice/match/label_test.go
+++ b/storage/logservice/match/label_test.go
@@ -1,7 +1,9 @@
 package match
 
 import (
-	"strings"
+	"github.com/stretchr/testify/assert"
+	"regexp"
+
 	"testing"
 
 	"github.com/kuoss/lethe/letheql/model"
@@ -41,14 +43,10 @@ func FuzzNodeLabelMatchEqual(f *testing.F) {
 	}
 	f.Fuzz(func(t *testing.T, label string) {
 		isMatch := verfityFunc(label)
-		/*
-			if label == "label_value" && isMatch == true {
-				// as we expected
-				// comment this branch for lint
-			}
-		*/
-		if label != "label_value" && isMatch == true {
-			t.Errorf("%q label is matched with ", label)
+		if label == "lable_value" {
+			assert.True(t, isMatch)
+		} else {
+			assert.False(t, isMatch)
 		}
 	})
 }
@@ -85,14 +83,10 @@ func FuzzNodeLabelMatchNotEqual(f *testing.F) {
 	}
 	f.Fuzz(func(t *testing.T, label string) {
 		isMatch := verfityFunc(label)
-		/*
-			if label != "label_value" && isMatch == true {
-				// as we expected
-				// comment this branch for lint
-			}
-		*/
-		if label != "label_value" && isMatch == false {
-			t.Errorf("label is not matched with %q", label)
+		if label == "lable_value" {
+			assert.False(t, isMatch)
+		} else {
+			assert.True(t, isMatch)
 		}
 	})
 }
@@ -127,11 +121,11 @@ func FuzzNodeLabelMatchRegexOnlyContains(f *testing.F) {
 	for _, tc := range testcases {
 		f.Add(tc)
 	}
+	re := regexp.MustCompile("^.+bar$")
 	f.Fuzz(func(t *testing.T, label string) {
-		isMatch := verfityFunc(label)
-		if !strings.Contains(label, "bar") && isMatch == true {
-			t.Errorf("label is matched with %q unexpectedly", label)
-		}
+		got := verfityFunc(label)
+		want := re.MatchString(label)
+		assert.Equal(t, got, want)
 	})
 }
 
@@ -165,10 +159,10 @@ func FuzzNodeLabelMatchRegexNotEqualOnlyContains(f *testing.F) {
 	for _, tc := range testcases {
 		f.Add(tc)
 	}
+	re := regexp.MustCompile("^.+bar$")
 	f.Fuzz(func(t *testing.T, label string) {
-		isMatch := verfityFunc(label)
-		if !strings.Contains(label, "bar") && isMatch == false {
-			t.Errorf("label is matched with %q unexpectedly", label)
-		}
+		got := verfityFunc(label)
+		want := !re.MatchString(label)
+		assert.Equal(t, got, want)
 	})
 }

--- a/storage/logservice/match/label_test.go
+++ b/storage/logservice/match/label_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/kuoss/lethe/letheql/model"
-	"github.com/kuoss/lethe/letheql/parser"
 	"github.com/prometheus/prometheus/model/labels"
 )
 
@@ -21,13 +20,6 @@ func FuzzNodeLabelMatchEqual(f *testing.F) {
 				Value: "label_value",
 			},
 		},
-		LineMatchers: []*model.LineMatcher{
-			&model.LineMatcher{
-				Op:    parser.PIPE_REGEX,
-				Value: "line_value",
-			},
-		},
-		TimeRange: model.TimeRange{},
 	}
 
 	funcs, err := getLabelMatchFuncs(nodeSel)
@@ -61,13 +53,6 @@ func FuzzNodeLabelMatchNotEqual(f *testing.F) {
 				Value: "label_value",
 			},
 		},
-		LineMatchers: []*model.LineMatcher{
-			&model.LineMatcher{
-				Op:    parser.PIPE_REGEX,
-				Value: "line_value",
-			},
-		},
-		TimeRange: model.TimeRange{},
 	}
 
 	funcs, err := getLabelMatchFuncs(nodeSel)
@@ -101,13 +86,6 @@ func FuzzNodeLabelMatchRegexOnlyContains(f *testing.F) {
 				Value: ".+bar",
 			},
 		},
-		LineMatchers: []*model.LineMatcher{
-			&model.LineMatcher{
-				Op:    parser.PIPE_REGEX,
-				Value: "line_value",
-			},
-		},
-		TimeRange: model.TimeRange{},
 	}
 
 	funcs, err := getLabelMatchFuncs(nodeSel)
@@ -139,13 +117,6 @@ func FuzzNodeLabelMatchRegexNotEqualOnlyContains(f *testing.F) {
 				Value: ".+bar",
 			},
 		},
-		LineMatchers: []*model.LineMatcher{
-			&model.LineMatcher{
-				Op:    parser.PIPE_REGEX,
-				Value: "line_value",
-			},
-		},
-		TimeRange: model.TimeRange{},
 	}
 
 	funcs, err := getLabelMatchFuncs(nodeSel)

--- a/storage/logservice/match/label_test.go
+++ b/storage/logservice/match/label_test.go
@@ -41,9 +41,12 @@ func FuzzNodeLabelMatchEqual(f *testing.F) {
 	}
 	f.Fuzz(func(t *testing.T, label string) {
 		isMatch := verfityFunc(label)
-		if label == "label_value" && isMatch == true {
-			// as we expected
-		}
+		/*
+			if label == "label_value" && isMatch == true {
+				// as we expected
+				// comment this branch for lint
+			}
+		*/
 		if label != "label_value" && isMatch == true {
 			t.Errorf("%q label is matched with ", label)
 		}
@@ -82,9 +85,12 @@ func FuzzNodeLabelMatchNotEqual(f *testing.F) {
 	}
 	f.Fuzz(func(t *testing.T, label string) {
 		isMatch := verfityFunc(label)
-		if label != "label_value" && isMatch == true {
-			// as we expected
-		}
+		/*
+			if label != "label_value" && isMatch == true {
+				// as we expected
+				// comment this branch for lint
+			}
+		*/
 		if label != "label_value" && isMatch == false {
 			t.Errorf("label is not matched with %q", label)
 		}

--- a/storage/logservice/match/label_test.go
+++ b/storage/logservice/match/label_test.go
@@ -1,0 +1,171 @@
+package match
+
+import (
+	"github.com/kuoss/lethe/letheql/model"
+	"github.com/kuoss/lethe/letheql/parser"
+	"github.com/prometheus/prometheus/model/labels"
+	"strings"
+	"testing"
+)
+
+func FuzzNodeLabelMatchEqual(f *testing.F) {
+	nodeSel := &model.LogSelector{
+		Name: "node",
+		LabelMatchers: []*labels.Matcher{
+			&labels.Matcher{
+				Type:  labels.MatchEqual,
+				Name:  "process",
+				Value: "label_value",
+			},
+		},
+		LineMatchers: []*model.LineMatcher{
+			&model.LineMatcher{
+				Op:    parser.PIPE_REGEX,
+				Value: "line_value",
+			},
+		},
+		TimeRange: model.TimeRange{},
+	}
+
+	funcs, err := getLabelMatchFuncs(nodeSel)
+	if err != nil {
+		f.Fail()
+	}
+
+	var verfityFunc MatchFunc
+	verfityFunc = funcs[0]
+
+	testcases := []string{"label_value", "non_label_value"}
+	for _, tc := range testcases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, label string) {
+		isMatch := verfityFunc(label)
+		if label == "label_value" && isMatch == true {
+			// as we expected
+		}
+		if label != "label_value" && isMatch == true {
+			t.Errorf("%q label is matched with ", label)
+		}
+	})
+}
+
+func FuzzNodeLabelMatchNotEqual(f *testing.F) {
+	nodeSel := &model.LogSelector{
+		Name: "node",
+		LabelMatchers: []*labels.Matcher{
+			&labels.Matcher{
+				Type:  labels.MatchNotEqual,
+				Name:  "process",
+				Value: "label_value",
+			},
+		},
+		LineMatchers: []*model.LineMatcher{
+			&model.LineMatcher{
+				Op:    parser.PIPE_REGEX,
+				Value: "line_value",
+			},
+		},
+		TimeRange: model.TimeRange{},
+	}
+
+	funcs, err := getLabelMatchFuncs(nodeSel)
+	if err != nil {
+		f.Fail()
+	}
+
+	var verfityFunc MatchFunc
+	verfityFunc = funcs[0]
+
+	testcases := []string{"label_value", "non_label_value"}
+	for _, tc := range testcases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, label string) {
+		isMatch := verfityFunc(label)
+		if label != "label_value" && isMatch == true {
+			// as we expected
+		}
+		if label != "label_value" && isMatch == false {
+			t.Errorf("label is not matched with %q", label)
+		}
+	})
+}
+
+func FuzzNodeLabelMatchRegexOnlyContains(f *testing.F) {
+	nodeSel := &model.LogSelector{
+		Name: "node",
+		LabelMatchers: []*labels.Matcher{
+			&labels.Matcher{
+				Type:  labels.MatchRegexp,
+				Name:  "process",
+				Value: ".+bar",
+			},
+		},
+		LineMatchers: []*model.LineMatcher{
+			&model.LineMatcher{
+				Op:    parser.PIPE_REGEX,
+				Value: "line_value",
+			},
+		},
+		TimeRange: model.TimeRange{},
+	}
+
+	funcs, err := getLabelMatchFuncs(nodeSel)
+	if err != nil {
+		f.Fail()
+	}
+
+	var verfityFunc MatchFunc
+	verfityFunc = funcs[0]
+
+	testcases := []string{"foobar", "foobaar", "regardless"}
+	for _, tc := range testcases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, label string) {
+		isMatch := verfityFunc(label)
+		if !strings.Contains(label, "bar") && isMatch == true {
+			t.Errorf("label is matched with %q unexpectedly", label)
+		}
+	})
+}
+
+func FuzzNodeLabelMatchRegexNotEqualOnlyContains(f *testing.F) {
+	nodeSel := &model.LogSelector{
+		Name: "node",
+		LabelMatchers: []*labels.Matcher{
+			&labels.Matcher{
+				Type:  labels.MatchNotRegexp,
+				Name:  "process",
+				Value: ".+bar",
+			},
+		},
+		LineMatchers: []*model.LineMatcher{
+			&model.LineMatcher{
+				Op:    parser.PIPE_REGEX,
+				Value: "line_value",
+			},
+		},
+		TimeRange: model.TimeRange{},
+	}
+
+	funcs, err := getLabelMatchFuncs(nodeSel)
+	if err != nil {
+		f.Fail()
+	}
+
+	var verfityFunc MatchFunc
+	verfityFunc = funcs[0]
+
+	testcases := []string{"foobar", "foobaar", "regardless"}
+	for _, tc := range testcases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, label string) {
+		isMatch := verfityFunc(label)
+		if !strings.Contains(label, "bar") && isMatch == false {
+			t.Errorf("label is matched with %q unexpectedly", label)
+		}
+	})
+}


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

현재 `storage/logservice/match` 하위의 파일들을 보면 `model.LogSelector`를 파라미터로 받고, 파라미터에 존재하는 `Label`을 `labels.MatchType`(`=`,`!=`,`=~`,`!~`)과 비교해주는 함수를 리턴해주고 있습니다(high order function).
리턴받은 함수가 우리가 의도한 `Label.MatchType`의 동작과 일치하는지 assert하고 싶은 의도로 작성한 Fuzz 테스트 코드입니다.

예를 들어 `FuzzNodeLabelMatchEqual`는
<`"label_value"`라는 Label(`string`)을 파라미터로 받는 경우에 `true`를 리턴하는 함수>를 `getLabelMatchFuncs`가 리턴해야합니다.

그래서 Fuzz테스트 부분에서는 `"label_value"`이 아닌 파라미터를 전달했는데도 `true`를 리턴받는다면 실패하도록 테스트하고 있습니다.

마찬가지로 `FuzzNodeLabelMatchNotEqual` 케이스의 경우 `"label_value"` 가 아닌 파라미터를 전달했는데 `false`를 실패하도록 테스트하고 있습니다.

정규식 `Matcher`의 경우 특정 정규식을 정하고 대응하는 검증 방법이 있는 경우 가능합니다. 테스트 코드에서는 `"+.bar"`  정규식을 사용했고, 대응하는 `strings.Cotains`메서드를 활용했습니다.

만약 `"+.bar"` 정규식(`bar`를 포함)이 `true`를 리턴했는데 `strings.Contains` 메서드가 `false`를 리턴했다면 실패하도록 되어있습니다.


#### Which issue(s) this PR fixes (관련 이슈):

- 테스트 코드 추가


#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

리뷰 감사합니다.


#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):


